### PR TITLE
Harden backend exec inputs

### DIFF
--- a/file-sharing/src/tabs/iSCSI/types/cluster/RBDManager.ts
+++ b/file-sharing/src/tabs/iSCSI/types/cluster/RBDManager.ts
@@ -5,7 +5,7 @@ import { LogicalVolume } from '@/tabs/iSCSI/types/cluster/LogicalVolume';
 import { RadosBlockDevice } from './RadosBlockDevice';
 import { Pool, PoolType } from "@/tabs/iSCSI/types/cluster/Pool";
 import {
-  BashCommand,
+  Command,
   ProcessError,
   safeJsonParse,
   Server,
@@ -36,12 +36,22 @@ export class RBDManager {
   }
  
     createRadosBlockDevice(name: string, size: number, parentPool: Pool, dataPool?: Pool) {
-        const dataPoolArgument =  dataPool === undefined ? "" :  `--data-pool ${dataPool.name}`
-
-        return this.server.execute(new BashCommand(`rbd create ${parentPool.name}/${name} --size ${size}B ${dataPoolArgument}`, [], this.commandOptionsWrite))
+        return this.server.execute(
+          new Command(
+            ["rbd", "create", `${parentPool.name}/${name}`, "--size", `${size}B`, ...(
+              dataPool === undefined ? [] : ["--data-pool", dataPool.name]
+            )],
+            this.commandOptionsWrite
+          )
+        )
         .andThen(() => 
-            this.server.execute(new BashCommand(`rbd map ${parentPool.name}/${name}`, [], this.commandOptionsWrite))
-            .andThen((mapProc) => this.server.execute(new BashCommand(`blockdev --getbsz ${mapProc.getStdout()}`, [], this.commandOptionsRead))
+            this.server.execute(
+              new Command(["rbd", "map", `${parentPool.name}/${name}`], this.commandOptionsWrite)
+            )
+            .andThen((mapProc) =>
+              this.server.execute(
+                new Command(["blockdev", "--getbsz", mapProc.getStdout().trim()], this.commandOptionsRead)
+              )
                 .andThen((blockSizeProc) => {
                     const blockSize = StringToIntCaster()(blockSizeProc.getStdout())
 
@@ -58,7 +68,7 @@ export class RBDManager {
     }
     getOnlineClusterNodes(): ResultAsync<Server[], ProcessError> {
       return this.server
-          .execute(new BashCommand(`pcs status xml`, [], this.commandOptionsRead))
+          .execute(new Command(["pcs", "status", "xml"], this.commandOptionsRead))
           .andThen((proc) => {
               const output = proc.getStdout();
               const parser = new DOMParser();
@@ -83,14 +93,65 @@ export class RBDManager {
 
 
     createLogicalVolumeFromRadosBlockDevices(logicalVolumeName: string, volumeGroupName: string, rbds: RadosBlockDevice[]) {
-        const rbdPaths = rbds.map((rbd) => rbd.filePath).join(' ');
+        const rbdPaths = rbds.map((rbd) => rbd.filePath);
         let createdLogicalVolume: LogicalVolume | null = null;
-        return ResultAsync.combine(rbds.map((rbd) => this.server.execute(new BashCommand(`pvcreate ${rbd.filePath}`, [], this.commandOptionsWrite)).map(() => new PhysicalVolume(rbd))))
-        .andThen((physicalVolumes) => this.server.execute(new BashCommand(`vgcreate ${volumeGroupName} ${rbdPaths}`, [], this.commandOptionsWrite)).map(() => new VolumeGroup(volumeGroupName, physicalVolumes,this.server)))
-        .andThen((volumeGroup) => this.server.execute(new BashCommand(`lvcreate -i ${rbds.length} -I 64 -l 100%FREE -n ${logicalVolumeName} ${volumeGroupName} ${rbdPaths}`, [], this.commandOptionsWrite))
-            .andThen(() => this.server.execute(new BashCommand(`lvdisplay /dev/${volumeGroupName}/${logicalVolumeName} --units B | grep 'LV Size' | awk '{print $3, $4}'`, [], this.commandOptionsRead))
-                .map((proc) => proc.getStdout())
-                .map((maximumSize) => {
+        return ResultAsync.combine(
+          rbds.map((rbd) =>
+            this.server
+              .execute(new Command(["pvcreate", rbd.filePath], this.commandOptionsWrite))
+              .map(() => new PhysicalVolume(rbd))
+          )
+        )
+        .andThen((physicalVolumes) =>
+          this.server
+              .execute(
+              new Command(["vgcreate", volumeGroupName, ...rbdPaths], this.commandOptionsWrite)
+            )
+            .map(() => new VolumeGroup(volumeGroupName, physicalVolumes, this.server))
+        )
+        .andThen(() =>
+          this.server
+            .execute(
+              new Command(
+                [
+                  "lvcreate",
+                  "-i",
+                  rbds.length.toString(),
+                  "-I",
+                  "64",
+                  "-l",
+                  "100%FREE",
+                  "-n",
+                  logicalVolumeName,
+                  volumeGroupName,
+                  ...rbdPaths,
+                ],
+                this.commandOptionsWrite
+              )
+            )
+            .andThen(() =>
+              this.server.execute(
+                new Command(
+                  [
+                    "lvs",
+                    "--reportformat",
+                    "json",
+                    "--units",
+                    "B",
+                    "-o",
+                    "lv_size",
+                    "-S",
+                    `lv_name=${logicalVolumeName}`,
+                  ],
+                  this.commandOptionsRead
+                )
+              )
+            )
+            .map((proc) => proc.getStdout())
+            .andThen(safeJsonParse<LogicalVolumeInfoJson>)
+            .map((info) => info?.report?.flatMap((r) => r.lv ?? []) ?? [])
+            .map((entries) => entries[0]?.lv_size ?? "")
+            .map((maximumSize) => {
                   
                   return this.server.getIpAddress(false).map((/* ip */) => {
                     createdLogicalVolume = new LogicalVolume(
@@ -101,14 +162,19 @@ export class RBDManager {
                       this.server // now has up-to-date ipAddress cached
                     );
                   });
-                                })
+                })
             )
         )
         .map(() => createdLogicalVolume!);
     }
 
     expandRadosBlockDevice(device: RadosBlockDevice, newSizeBytes: number) {
-        return this.server.execute(new BashCommand(`rbd resize --size ${newSizeBytes}B ${device.deviceName}`, [], this.commandOptionsWrite));
+        return this.server.execute(
+          new Command(
+            ["rbd", "resize", "--size", `${newSizeBytes}B`, device.deviceName],
+            this.commandOptionsWrite
+          )
+        );
     }
 
     expandLogicalVolume(volume: LogicalVolume, newSizeBytes: number) {
@@ -116,13 +182,19 @@ export class RBDManager {
 
         return ResultAsync.combine(volume.volumeGroup.volumes.map((volume) => 
             this.expandRadosBlockDevice(volume.rbd, newSizePerRBD)
-            .andThen(() => this.server.execute(new BashCommand(`pvresize ${volume.rbd.filePath}`, [], this.commandOptionsWrite)))
+            .andThen(() => this.server.execute(new Command(["pvresize", volume.rbd.filePath], this.commandOptionsWrite)))
         ))
-        .andThen(() => this.server.execute(new BashCommand(`lvextend -l +100%FREE ${volume.filePath}`, [], this.commandOptionsWrite)));
+        .andThen(() =>
+          this.server.execute(
+            new Command(["lvextend", "-l", "+100%FREE", volume.filePath], this.commandOptionsWrite)
+          )
+        );
     }
 
     fetchAvaliablePools(server: Server = this.server): ResultAsync<Pool[], ProcessError> {
-        return server.execute(new BashCommand(`ceph osd pool ls detail --format json`, [], this.commandOptionsRead))
+        return server.execute(
+          new Command(["ceph", "osd", "pool", "ls", "detail", "--format", "json"], this.commandOptionsRead)
+        )
             .map((proc) => proc.getStdout())
             .andThen(safeJsonParse<PoolInfoJson>)
             .map((allPoolInfo) => allPoolInfo.filter((poolInfo) => poolInfo !== undefined))
@@ -163,12 +235,14 @@ export class RBDManager {
         this.allServers.map((server) => {
     
           return ResultAsync.combine([
-            server.execute(new BashCommand(`rbd showmapped --format json`, [], this.commandOptionsRead))
+            server.execute(new Command(["rbd", "showmapped", "--format", "json"], this.commandOptionsRead))
               .map((proc) => proc.getStdout())
               .andThen(safeJsonParse<MappedRBDJson>)
               .mapErr((err) => new ProcessError(`Unable to get mapped RBDs from ${server}: ${err}`)),
               
-            server.execute(new BashCommand(`pvs --reportformat json -o pv_name,vg_name`, [], this.commandOptionsRead))
+            server.execute(
+              new Command(["pvs", "--reportformat", "json", "-o", "pv_name,vg_name"], this.commandOptionsRead)
+            )
               .map((proc) => proc.getStdout())
               .andThen(safeJsonParse<PVToVGJson>)
               .map((parsed) => {
@@ -223,11 +297,22 @@ export class RBDManager {
       return ResultAsync.combine(
         this.allServers.map((server) =>
           // 1) get all LVs for this server
-          server.execute(  new BashCommand(
-            `lvs --reportformat json --units B \
-             -o lv_name,vg_name,lv_size,lv_path,lv_attr \
-             -S 'vg_name!="rl" && lv_name!~"^(root|home|swap)$"'`
-          , [], this.commandOptionsRead))
+          server.execute(
+            new Command(
+              [
+                "lvs",
+                "--reportformat",
+                "json",
+                "--units",
+                "B",
+                "-o",
+                "lv_name,vg_name,lv_size,lv_path,lv_attr",
+                "-S",
+                "vg_name!=rl && lv_name!~^(root|home|swap)$",
+              ],
+              this.commandOptionsRead
+            )
+          )
             .map(p => {
               const out = p.getStdout()
               // console.log("LVS raw stdout: ", out);
@@ -242,7 +327,9 @@ export class RBDManager {
             .andThen(lvList =>
               ResultAsync.combine([
                 okAsync(lvList),
-                server.execute(new BashCommand(`pvs --reportformat json --units B -o pv_name,vg_name`, [], this.commandOptionsRead))
+                server.execute(
+                  new Command(["pvs", "--reportformat", "json", "--units", "B", "-o", "pv_name,vg_name"], this.commandOptionsRead)
+                )
                   .map(p => {
                     const out = p.getStdout()
                     // console.log("pvs raw stdout: ", out);
@@ -308,19 +395,20 @@ export class RBDManager {
     }
     
     fetchExistingImageNames() {
-        return this.server.execute(new BashCommand(`rbd list`, [], this.commandOptionsRead))
+        return this.server.execute(new Command(["rbd", "list"], this.commandOptionsRead))
         .map((proc) => proc.getStdout())
         .map((output) => output.trim().split('\n'));
     }
 
     getBlockSizeFromDevicePath(path: Pick<VirtualDevice, "filePath"> | string, server: Server) {
-        return server.execute(new BashCommand(`blockdev --getbsz ${path}`, [], this.commandOptionsRead))
+        const devicePath = typeof path === "string" ? path : path.filePath;
+        return server.execute(new Command(["blockdev", "--getbsz", devicePath], this.commandOptionsRead))
                     .map((proc) => StringToIntCaster()(proc.getStdout()))
                     .andThen((maybeNumber) => maybeNumber.isSome() ? okAsync(maybeNumber.some()) : errAsync(new ProcessError(`Unable to determine block size for device: ${path}`)))
     }
 
     getMaximumSizeFromRBDName(rbdName: Pick<VirtualDevice, "deviceName"> | string,parentPool: Pool, server: Server) {
-        return server.execute(new BashCommand(`rbd info ${parentPool.name}/${rbdName} --format json`, [], this.commandOptionsRead))
+        return server.execute(new Command(["rbd", "info", `${parentPool.name}/${rbdName}`, "--format", "json"], this.commandOptionsRead))
                     .map((proc) => proc.getStdout())
                     .andThen(safeJsonParse<RBDInfoJson>)
                     .map((rbdInfoEntry) => StringToIntCaster()(rbdInfoEntry.size!))
@@ -329,7 +417,7 @@ export class RBDManager {
     }
 
     getDataPoolForRBDName(rbdName: Pick<VirtualDevice, "deviceName"> | string, parentPool: Pool, server: Server) {
-        return server.execute(new BashCommand(`rbd info ${parentPool.name}/${rbdName}`, [], this.commandOptionsRead))
+        return server.execute(new Command(["rbd", "info", `${parentPool.name}/${rbdName}`], this.commandOptionsRead))
                     .map((proc) => proc.getStdout())
                     .andThen(safeJsonParse<RBDInfoJson>)
                     .map((rbdInfoEntry) => {


### PR DESCRIPTION
## Summary
- replace shell-based invocations with argv-based commands where practical in iSCSI and RBD helpers
- add input validation for config paths and iSCSI/PCS identifiers to prevent malformed or multi-line inputs
- enforce single-line PCS resource arguments to avoid unsafe updates

## Testing
- not run (not requested)
